### PR TITLE
eslintなどの設定を変更

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,5 +18,7 @@
         "tsconfigRootDir": ".",
         "project": "./tsconfig.json"
     },
-    "rules": {}
+    "rules": {
+      "indent": ["error", 2]
+    }
   }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,24 +1,24 @@
 {
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking",
-  
-      "plugin:prettier/recommended",
-      "prettier/@typescript-eslint"
-    ],
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "env": { "browser": true, "node": true, "es6": true },
-    "parserOptions": {
-        "sourceType": "module",
-        "tsconfigRootDir": ".",
-        "project": "./tsconfig.json"
-    },
-    "rules": {
-      "indent": ["error", 2]
-    }
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+
+    "plugin:prettier/recommended",
+    "prettier/@typescript-eslint"
+  ],
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "env": { "browser": true, "node": true, "es6": true },
+  "parserOptions": {
+      "sourceType": "module",
+      "tsconfigRootDir": ".",
+      "project": "./tsconfig.json"
+  },
+  "rules": {
+    "indent": ["error", 2]
   }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,8 @@
 
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
-		"dbaeumer.vscode-eslint"
+		"dbaeumer.vscode-eslint",
+		"editorconfig.editorconfig"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "start": "webpack-dev-server --open",
     "build": "webpack",
     "watch": "webpack -w",
-    "lint": "eslint \"src/**(.ts|.tsx)\"",
-    "fix": "eslint \"src/**(.ts|.tsx)\" --fix"
+    "lint": "eslint \"src/**/*@(.ts|.tsx)\"",
+    "fix": "eslint \"src/**/*@(.ts|.tsx)\" --fix"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "start": "webpack-dev-server --open",
     "build": "webpack",
     "watch": "webpack -w",
-    "lint": "eslint \"src/*\"",
-    "fix": "eslint \"src/*\" --fix"
+    "lint": "eslint \"src/**(.ts|.tsx)\"",
+    "fix": "eslint \"src/**(.ts|.tsx)\" --fix"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- npm scriptのeslint呼び出しコマンドにミスがあったので修正
  - src直下の.tsファイルしか該当していなかったので、srd下の全ての.ts/.tsxファイルが該当するように変更
- vscodeのeditorconfig拡張をextensions.jsonに追記
- eslintのrulesにインデントルール(スペース, 2)を追加