### PR TITLE
SkyWay周りのリファクタリング

### DIFF
--- a/src/effects/SkyWaySFU.ts
+++ b/src/effects/SkyWaySFU.ts
@@ -5,6 +5,9 @@ import * as SkyWay from "skyway-js";
 import * as Array from "fp-ts/lib/Array";
 import * as U from "../util";
 import sampleCombine from "xstream/extra/sampleCombine";
+import * as Op from "../StreamOperators";
+import { Option, some, none, fold, isSome } from "fp-ts/lib/Option";
+import * as StateE from "../effects/State";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const Peer = require("skyway-js");
 
@@ -21,14 +24,14 @@ export type PeerID = string;
 
 export type Connection = {
   peerID: PeerID;
-  updateMediaStream$: Stream<MediaStream>;
-  json$: Stream<Record<string, unknown>>;
+  updateMediaStream$: MemoryStream<MediaStream>;
+  json$: MemoryStream<Record<string, unknown>>;
 };
 
 export type Source = {
   // TODO: joinOtherとかいらないのでは？
   connection$: Stream<Connection>;
-  connections$: Stream<Connection[]>;
+  connections$: MemoryStream<Connection[]>;
   data$: Stream<[PeerID, Record<string, unknown>]>;
   stream$: Stream<[PeerID, MediaStream]>;
   joinOther$: Stream<PeerID>;
@@ -61,6 +64,109 @@ export const nameSi: (so: Si) => NamedSi = (si) => {
 };
 // ---------------------------------------------------------------------------------
 
+const onRoom = (room: SkyWay.SfuRoom): Source => {
+  type DataObject = { src: PeerID; data: Record<string, unknown> };
+  const peerLeave$: Stream<PeerID> = fromEvent(room, "peerLeave").debug(
+    "peerLeave"
+  );
+  const peerJoin$: Stream<PeerID> = fromEvent(room, "peerJoin").debug(
+    "peerJoin"
+  );
+  // 既にいるメンバーのpeerJoinは送られてこないがstreamだけは送られてくる
+  const stream$: Stream<[PeerID, MediaStream]> = fromEvent(room, "stream")
+    .map<[PeerID, MediaStream]>((s: SkyWay.RoomStream) => [s.peerId, s])
+    .debug("stream!!!!!!!!!!!!!");
+  const data$: Stream<[PeerID, Record<string, unknown>]> = fromEvent(
+    room,
+    "data"
+  ).map((d: SkyWay.RoomData) => [d.src, d.data]);
+  data$.subscribe({
+    next: (d) => {
+      console.log("received", d);
+    },
+  });
+
+  const endWhenLeave = (id: PeerID) => <T>(s: Stream<T>): Stream<T> =>
+    s.endWhen(peerLeave$.filter((x) => x == id));
+  const filteredStream = (id: PeerID): Stream<MediaStream> =>
+    stream$
+      .filter((s) => s[0] == id)
+      .map((s) => s[1])
+      .compose(endWhenLeave(id))
+      .map((s): MediaStream => s);
+  const filteredJson = (id: PeerID): Stream<Record<string, unknown>> =>
+    data$
+      .filter((d) => d[0] == id)
+      .map((d) => d[1])
+      .compose(endWhenLeave(id));
+  const mkConnection = (peerID: PeerID) => (
+    stream0: Option<MediaStream>
+  ): Connection => ({
+    peerID: peerID,
+    updateMediaStream$: fold(
+      () => filteredStream(peerID),
+      (s: MediaStream) => filteredStream(peerID).startWith(s)
+    )(stream0),
+    json$: filteredJson(peerID),
+  });
+
+  type ConDataDef = {
+    join: PeerID;
+    joinWithStream: [PeerID, MediaStream];
+    leave: PeerID;
+  };
+  // const mkJoin = (x: PeerID) => U.mkSumV(conDataProxy)("join")(x);
+  // const mkJoinWS = (x: [PeerID, MediaStream]) =>
+  //   U.mkSumV(conDataProxy)("joinWithStream")(x);
+  // const mkLeave = (x: PeerID) => U.mkSumV(conDataProxy)("leave")(x);
+  const conDataProxy = U.proxy<ConDataDef>();
+  const rawCon$: Stream<U.Sum<ConDataDef>> = xs
+    .merge(
+      peerJoin$.map(U.mkSumV(conDataProxy)("join")),
+      stream$.map(U.mkSumV(conDataProxy)("joinWithStream")),
+      peerLeave$.map(U.mkSumV(conDataProxy)("leave"))
+    )
+    .debug("rawCon$");
+
+  const res$ = rawCon$.fold<[Option<Connection>, Connection[]]>(
+    ([_, s], v) =>
+      U.caseOf(conDataProxy)(v)({
+        join: (id) => {
+          const con = mkConnection(id)(none);
+          return s.find((c) => c.peerID == id)
+            ? [none, s]
+            : [some(con), s.concat([con])];
+        },
+        joinWithStream: ([id, stream]) => {
+          const con = mkConnection(id)(some(stream));
+          return s.find((c) => c.peerID == id)
+            ? [none, s]
+            : [some(con), s.concat([con])];
+        },
+        leave: (id) =>
+          s.find((c) => c.peerID == id)
+            ? [none, s.filter((c) => id != c.peerID)]
+            : [none, s],
+      }),
+    [none, []]
+  );
+  const connection$ = res$
+    .map((x) => x[0])
+    .filter(isSome)
+    .map((s) => s.value)
+    .debug("connection$");
+  const connections$ = res$.map((x) => x[1]).debug("connections");
+
+  return {
+    connection$: connection$,
+    connections$: connections$,
+    data$: data$,
+    stream$: stream$,
+    joinOther$: peerJoin$,
+    leaveOther$: peerLeave$,
+  };
+};
+
 export function run<Sos extends NamedSo, Sis extends NamedSi>(
   component: Component<Sos, Sis>
 ): Component<Omit<Sos, Name>, Omit<Sis, Name>> {
@@ -76,116 +182,78 @@ export function run<Sos extends NamedSo, Sis extends NamedSi>(
     const sinks: Sis = component({ ...sources, ...nameSo(so) } as Sos);
     const si: Sink = getSi(sinks);
 
-    function withRoom(room: SkyWay.SfuRoom): void {
-      si.sendJSON$.subscribe({
-        next: (json: Record<string, unknown>) => {
-          console.log("send JSON: ", json);
-          room.send(json);
+    const peer = new Peer({
+      key: "02cc71f9-6aac-4070-8251-037792b2ed60",
+    });
+
+    const room$: Stream<SkyWay.SfuRoom> = xs
+      .combine(si.userStream$, si.join$)
+      .map(([stream, roomID]) => {
+        const strID = toString(roomID);
+        return peer.joinRoom(strID, { mode: "sfu", stream: stream });
+      });
+
+    si.sendJSON$.subscribe({
+      next: (x) => {
+        console.log("sendJSON$: ", x);
+      },
+    });
+    xs.combine(room$, Op.delayUntil(room$)(si.sendJSON$)).subscribe({
+      next: ([room, data]) => {
+        console.log("delayed sendJSON$: ", data);
+        room.send(data);
+      },
+    });
+    const so$ = room$.map(onRoom);
+    // TODO: 以下のコード群もっと上手く書けるようにutil整備する
+    so$
+      .map((s) => s.connection$)
+      .flatten()
+      .subscribe({
+        next: (x) => {
+          so.connection$.shamefullySendNext(x);
         },
       });
-
-      type DataObject = { src: PeerID; data: Record<string, unknown> };
-      const peerLeave$: Stream<PeerID> = fromEvent(room, "peerLeave").debug(
-        "peerLeave"
-      );
-      const peerJoin$: Stream<PeerID> = fromEvent(room, "peerJoin").debug(
-        "peerJoin"
-      );
-      // 既にいるメンバーのpeerJoinは送られてこないがstreamだけは送られてくる
-      const stream$: Stream<SkyWay.RoomStream> = fromEvent(room, "stream")
-        .remember()
-        .debug("stream!!!!!!!!!!!!!");
-      const data$: Stream<DataObject> = fromEvent(room, "data").remember();
-      data$.take(10).subscribe({
-        next: (d) => {
-          console.log("received", d);
-        },
-      });
-
-      const endWhenLeave = (id: PeerID) => <T>(s: Stream<T>): Stream<T> =>
-        s.endWhen(peerLeave$.filter((x) => x == id));
-      const filteredStream = (id: PeerID): Stream<MediaStream> =>
-        stream$
-          .filter((s) => s.peerId == id)
-          .compose(endWhenLeave(id))
-          .map((s): MediaStream => s);
-      const filteredJson = (id: PeerID): Stream<Record<string, unknown>> =>
-        data$
-          .filter((d) => d.src == id)
-          .map((d) => d.data)
-          .compose(endWhenLeave(id));
-      const mkConnection = (peerID: PeerID): Connection => ({
-        peerID: peerID,
-        updateMediaStream$: filteredStream(peerID),
-        json$: filteredJson(peerID),
-      });
-
-      type ConDataDef = { joinMaybe: PeerID; leave: PeerID };
-      const conDataProxy = U.proxy<ConDataDef>();
-      const con$: Stream<U.Sum<ConDataDef>> = xs.merge(
-        peerJoin$.map(U.mkSumV(conDataProxy)("joinMaybe")),
-        stream$.map((s) => s.peerId).map(U.mkSumV(conDataProxy)("joinMaybe")),
-        peerLeave$.map(U.mkSumV(conDataProxy)("leave"))
-      );
-      const connections$: Stream<Connection[]> = con$.fold(
-        (acc: Connection[], v) =>
-          U.caseOf(conDataProxy)(v)({
-            joinMaybe: (id) =>
-              acc.find((c) => c.peerID == id)
-                ? acc
-                : acc.concat([mkConnection(id)]),
-            leave: (id) => acc.filter((c) => id != c.peerID),
-          }),
-        []
-      );
-
-      connections$.subscribe({
+    so$
+      .map((s) => s.connections$)
+      .flatten()
+      .subscribe({
         next: (x) => {
           so.connections$.shamefullySendNext(x);
         },
       });
-      data$.subscribe({
-        next: (d) => so.data$.shamefullySendNext([d.src, d.data]),
-      });
-      stream$.subscribe({
-        next: (s) => {
-          so.stream$.shamefullySendNext([s.peerId, s]);
-          so.connection$.shamefullySendNext(mkConnection(s.peerId));
+    so$
+      .map((s) => s.data$)
+      .flatten()
+      .subscribe({
+        next: (x) => {
+          so.data$.shamefullySendNext(x);
         },
       });
-      peerJoin$.subscribe({
+    so$
+      .map((s) => s.stream$)
+      .flatten()
+      .subscribe({
+        next: (x) => {
+          so.stream$.shamefullySendNext(x);
+        },
+      });
+    so$
+      .map((s) => s.joinOther$)
+      .flatten()
+      .subscribe({
         next: (x) => {
           so.joinOther$.shamefullySendNext(x);
         },
       });
-
-      peerLeave$.subscribe({
-        next: (x) => so.leaveOther$.shamefullySendNext(x),
+    so$
+      .map((s) => s.leaveOther$)
+      .flatten()
+      .subscribe({
+        next: (x) => {
+          so.leaveOther$.shamefullySendNext(x);
+        },
       });
-    }
-
-    const peer = new Peer({
-      key: "02cc71f9-6aac-4070-8251-037792b2ed60",
-    });
-    const room$: Stream<SkyWay.SfuRoom> = xs.create();
-    xs.combine(si.userStream$, si.join$).subscribe({
-      next: ([stream, roomID]) => {
-        console.log("userStream$: ", stream);
-        const strID = toString(roomID);
-        const room = peer.joinRoom(strID, { mode: "sfu", stream: stream });
-        room$.shamefullySendNext(room);
-      },
-    });
-
-    room$.subscribe({ next: withRoom });
-    room$.subscribe({
-      next: (room) => {
-        room.on("stream", (s) => {
-          console.log("stream2!!!!!!!!!");
-        });
-        console.log("start stream observe");
-      },
-    });
 
     return { ...sinks };
   };


### PR DESCRIPTION
https://github.com/sawakai/sawakai/issues/16
# 変更点
- SkyWaySFU effectを書き直すことで動作が予測しづらかった非同期的な書き方がなくなり、潜在的なバグが消えたかもしれない
- 通信が確立されないバグの原因の一つに、相手のSkyWaySFU処理の準備が整う直前のタイミングでゲームIDの通知が届いてしまうというものがあったのでゲームID通知にディレイをかけた。またSkyWay側でUDP通信が使われているためにそもそもデータ全般の信頼性が怖いので、たまに再送する処理を入れた
  - 相手の反応を見ずにとりあえず再送するがさつな方針だがブロードキャストしかできない回線で毎回反応を伺うより実用的だと判断した
  - 再送処理の時間間隔は指数的に増加する
- 人が退出したときにゲームIDの表示が更新されないバグもあり、回避策を打ったがあまり綺麗じゃないので今後書き直すべき (https://github.com/sawakai/sawakai/issues/39)