### PR TITLE
音量正規化処理の安定性を改善した

### DIFF
--- a/src/AudioWorkletProcessor/ForegroundNormalizer.ts
+++ b/src/AudioWorkletProcessor/ForegroundNormalizer.ts
@@ -145,7 +145,7 @@ class ForegroundNormalizer extends AudioWorkletProcessor
 
     // 背景音の割合が大きいとき正規化係数の更新を避ける
     if (foregroundSize < backgroundSize * 0.1) {
-      console.log("喋ってねえよ");
+      // console.log("喋ってねえよ");
       return;
     }
 


### PR DESCRIPTION
https://github.com/sawakai/sawakai/issues/41
https://github.com/sawakai/sawakai/issues/48

ForegroundNormalizerを書き直した。
issue 41と48は様子を見てcloseする。

# 変更点
- 背景音の割合が大きい=喋っていないときは内部状態の更新を行わないようにしていたが、これを内部状態を更新し正規化係数だけ更新しないように変更
  - 喋っていない状態でも内部の音量検出処理だけは動き続けるようになったので、マイクの音量が急に小さくなったりしても対応できる。平均背景音レベルから{backgroundRange}dB(現在の設定では15dB)以上大きい音を出すと正規化係数の更新が再開される
- 正規化係数が何らかの原因で計算できなかったときはログを出力するようにした
  - 起動直後とかに計算に失敗するのはともかく、通話中に何度も失敗されたら原因を調べる必要がある