### PR TITLE
暗騒音を実装

### DIFF
--- a/src/AudioWorkletProcessor/WhiteNoise.ts
+++ b/src/AudioWorkletProcessor/WhiteNoise.ts
@@ -1,0 +1,31 @@
+import { ProcOptions, defaultOptions } from "./WhiteNoiseParam";
+import { AudioWorkletProcessorInterface, Options } from "./types";
+import { dB2lin } from "./util";
+import { toRequired, normalDistribution } from "../util";
+
+declare class AudioWorkletProcessor {
+  readonly port: MessagePort;
+}
+declare const sampleRate: number;
+declare function registerProcessor(a: unknown, b: unknown): void;
+
+export class WhiteNoise extends AudioWorkletProcessor
+  implements AudioWorkletProcessorInterface {
+  readonly param: Required<ProcOptions>;
+  constructor(options: Options<ProcOptions>) {
+    super();
+    this.param = toRequired(defaultOptions)(options.processorOptions);
+  }
+
+  process(_: Float32Array[][], outputs: Float32Array[][]): boolean {
+    const output = outputs[0][0];
+
+    for (let i = 0; i < output.length; i++) {
+      output[i] = normalDistribution(1)(0);
+      output[i] *= dB2lin(this.param.gain);
+    }
+    return true;
+  }
+}
+
+registerProcessor("white-noise", WhiteNoise);

--- a/src/AudioWorkletProcessor/WhiteNoiseParam.ts
+++ b/src/AudioWorkletProcessor/WhiteNoiseParam.ts
@@ -1,0 +1,7 @@
+export type ProcOptions = Partial<{
+  gain: number;
+}>;
+
+export const defaultOptions: Required<ProcOptions> = {
+  gain: 0,
+};

--- a/src/StreamOperators.ts
+++ b/src/StreamOperators.ts
@@ -58,3 +58,8 @@ export const exponentialRetry = (rate: number) => (firstDelay: number) => <T>(
       return b$.mapTo(sig);
     })
     .flatten();
+
+export const withElapsedTime = <T>(s: Stream<T>): Stream<[T, number]> => {
+  const start = performance.now();
+  return s.map((x) => [x, performance.now() - start]);
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -98,3 +98,15 @@ export const toRequired = <T>(dflt: Required<T>) => (
   );
   return (Object.fromEntries(ret) as unknown) as Required<T>;
 };
+
+// mean 平均
+// sd 標準僅差
+export const normalDistribution = (sd: number) => (mean: number): number => {
+  const x = Math.random();
+  const y = Math.random();
+
+  const z1 = Math.sqrt(-2 * Math.log(x)) * Math.cos(2 * Math.PI * y);
+  // const z2 = Math.sqrt(-2 * Math.log(x)) * Math.sin(2 * Math.PI * y);
+
+  return mean + z1 * sd;
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,6 +57,8 @@ const audioWorkletProcessorConfig = {
     "AudioWorkletProcessor/ForegroundNormalizer":
       "./src/AudioWorkletProcessor/ForegroundNormalizer.ts",
     "AudioWorkletProcessor/CmpExper": "./src/AudioWorkletProcessor/CmpExper.ts",
+    "AudioWorkletProcessor/WhiteNoise":
+      "./src/AudioWorkletProcessor/WhiteNoise.ts",
   },
   devServer: {
     contentBase: outputPath,


### PR DESCRIPTION
#52 
# 変更点
- 暗騒音を実装
  - WebAudioAPIのフィルターでホワイトノイズ(ホワイトガウスノイズ)のスペクトラムをいじって音の土台を作る
  - それだけでは変化が乏しいので、土台にpeakingフィルタをかけその周波数とゲインを不規則に変化させることで遠い風の音のような感じを再現
    - 不規則に変化させる部分は周波数のバラバラなsin関数を足し合わせることで実現している
- 暗騒音のパラメータを調整
  - 誰にとっても不快にならない暗騒音のモデルとして「山間の田舎」をイメージして調整した
  - 音量はとりあえず少し小さめに感じるくらいにしておいた
  - 最終的には、慣れてくれば全く気にならないが耳を澄ました時やふとした時に聴こえてくるくらいが理想...

### 外っぽくなったか？
- 主観で言えば気持ちよくはなった
- すぐに評価を下せないので今後少しずつ改善していきたい